### PR TITLE
Fix label checking incorrect box when clicked

### DIFF
--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
                 <label for="detect-packers">Detect packers and obfuscators?</label>
                 <br>
                 <input class="checkbox" type="checkbox" id="brace-preserve-inline">
-                <label for="keep-array-indentation">Preserve inline braces/code blocks?</label>
+                <label for="brace-preserve-inline">Preserve inline braces/code blocks?</label>
                 <br>
                 <input class="checkbox" type="checkbox" id="keep-array-indentation">
                 <label for="keep-array-indentation">Keep array indentation?</label>


### PR DESCRIPTION
I noticed that "Preserve inline braces/code blocks?" label was ticking "Keep array indentation?" checkbox